### PR TITLE
Fix for running in THREADED=False mode

### DIFF
--- a/mtapi/mtapi.py
+++ b/mtapi/mtapi.py
@@ -67,6 +67,7 @@ class Mtapi(object):
         self._MAX_TRAINS = max_trains
         self._MAX_MINUTES = max_minutes
         self._EXPIRES_SECONDS = expires_seconds
+        self._THREADED = threaded
         self._stations = {}
         self._stops_to_stations = {}
         self._routes = {}
@@ -212,7 +213,7 @@ class Mtapi(object):
         return out
 
     def is_expired(self):
-        if self.threader and self.threader.restart_if_dead():
+        if self._THREADED and self.threader and self.threader.restart_if_dead():
             return False
         elif self._EXPIRES_SECONDS:
             age = datetime.datetime.now(TZ) - self._last_update


### PR DESCRIPTION
Running with THREADED=False causes an error because 'threader' attribute won't exist when it gets checked in.  Made a small change to add _THREADED attribute to the Mtapi object and check it first in the is_expired() function where it was failing when not running in threaded mode.

  File "/home/ubuntu/workspace/app.py", line 106, in by_route
    
  File "/home/ubuntu/workspace/mtapi/mtapi.py", line 196, in get_by_route
    
  File "/home/ubuntu/workspace/mtapi/mtapi.py", line 215, in is_expired
    
AttributeError: 'Mtapi' object has no attribute 'threader'

