### PR TITLE
Remove MTA API key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ This app makes use of Python threads. If running under uWSGI include the --enabl
 
 ## Settings
 
-- **MTA_KEY** (required)  
-The API key provided at hhttps://api.mta.info/#/signup
-*default: None*
-
 - **STATIONS_FILE** (required)  
 Path to the JSON file containing station information. See [Generating a Stations File](#generating-a-stations-file) for more info.  
 *default: None*
@@ -53,7 +49,7 @@ How frequently the app will request fresh data from the MTA API.
 *default: 60*
 
 - **THREADED**  
-Enable background data refresh. This will prevent requests from hanging while new data is retreived from the MTA API.  
+Enable background data refresh. This will prevent requests from hanging while new data is retrieved from the MTA API.  
 *default: True*
 
 - **DEBUG**  

--- a/app.py
+++ b/app.py
@@ -52,7 +52,6 @@ class CustomJSONEncoder(json.JSONEncoder):
         return JSONEncoder.default(self, obj)
 
 mta = Mtapi(
-    app.config['MTA_KEY'],
     app.config['STATIONS_FILE'],
     max_trains=app.config['MAX_TRAINS'],
     max_minutes=app.config['MAX_MINUTES'],

--- a/mtapi/mtapi.py
+++ b/mtapi/mtapi.py
@@ -67,8 +67,7 @@ class Mtapi(object):
         'https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-g'  # G
     ]
 
-    def __init__(self, key, stations_file, expires_seconds=60, max_trains=10, max_minutes=30, threaded=False):
-        self._KEY = key
+    def __init__(self, stations_file, expires_seconds=60, max_trains=10, max_minutes=30, threaded=False):
         self._MAX_TRAINS = max_trains
         self._MAX_MINUTES = max_minutes
         self._EXPIRES_SECONDS = expires_seconds
@@ -108,7 +107,6 @@ class Mtapi(object):
     def _load_mta_feed(self, feed_url):
         try:
             request = urllib.request.Request(feed_url)
-            request.add_header('x-api-key', self._KEY)
             with contextlib.closing(urllib.request.urlopen(request)) as r:
                 data = r.read()
                 return FeedResponse(data)

--- a/settings.cfg.sample
+++ b/settings.cfg.sample
@@ -1,4 +1,3 @@
-MTA_KEY = 'your-mta-key-here'
 STATIONS_FILE = './data/stations.json'
 CROSS_ORIGIN = 'http://yourdomain.com'
 MAX_TRAINS=10

--- a/tests/test_mtapi.py
+++ b/tests/test_mtapi.py
@@ -3,7 +3,6 @@ from mtapi import Mtapi
 def test_init():
     from app import app
     mta = Mtapi(
-        app.config['MTA_KEY'],
         app.config['STATIONS_FILE'],
         max_trains=app.config['MAX_TRAINS'],
         max_minutes=app.config['MAX_MINUTES'],


### PR DESCRIPTION
I noticed that [the MTA no longer requires API keys](https://api.mta.info/#/). While the presence of an API key in the request headers don't seem to adversely affect anything, removing it might avoid confusion for someone in the future.